### PR TITLE
Fixes for git cloning and docker run issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.png filter=lfs diff=lfs merge=lfs -text

--- a/backend/openmlr/keys/manager.py
+++ b/backend/openmlr/keys/manager.py
@@ -12,7 +12,7 @@ class KeyManager:
     """Manages SSH private keys stored in a dedicated directory."""
 
     def __init__(self, keys_dir: str | Path = None):
-        self.keys_dir = Path(keys_dir) if keys_dir else Path(__file__).parent.parent.parent.parent.parent / ".keys"
+        self.keys_dir = Path(keys_dir) if keys_dir else Path(__file__).parent.parent.parent.parent / ".keys"
         self._ensure_dir()
 
     def _ensure_dir(self) -> None:


### PR DESCRIPTION
This pull request makes two small but important changes related to repository configuration and the SSH key management logic.

Repository configuration:

* Removed the Git LFS filter for `.png` files from `.gitattributes`, meaning `.png` files will no longer be tracked using Git LFS.

Key management logic:

* Updated the default path for the SSH keys directory in the `KeyManager` class (`backend/openmlr/keys/manager.py`) to be one level higher, making the path more consistent with the project structure.