### PR TITLE
fix bugs

### DIFF
--- a/backend/openmlr/agent/llm.py
+++ b/backend/openmlr/agent/llm.py
@@ -6,7 +6,7 @@ import os
 from collections.abc import AsyncGenerator
 
 from ..config import AgentConfig
-from .types import LLMResult, ToolCall
+from .types import LLMResult, ThinkingChunk, ToolCall
 
 
 class LLMProvider:
@@ -113,6 +113,18 @@ class LLMProvider:
         return model_name.lower().startswith("anthropic/")
 
     @staticmethod
+    def _supports_thinking(model_name: str) -> bool:
+        """Check if an Anthropic model supports extended thinking (Claude 3.7+, Claude 4+)."""
+        normalized = LLMProvider._normalize_model(model_name).lower()
+        thinking_patterns = [
+            "claude-3-7",
+            "claude-3.7",  # Claude 3.7 Sonnet
+            "claude-sonnet-4",
+            "claude-opus-4",  # Claude 4 family
+        ]
+        return any(p in normalized for p in thinking_patterns)
+
+    @staticmethod
     def _uses_anthropic_format(model_name: str, custom_providers: list | None = None) -> bool:
         """Check if model uses Anthropic message format (native Anthropic, OpenCode Go Anthropic, or custom provider with anthropic-sdk)."""
         if LLMProvider._is_anthropic_model(model_name):
@@ -139,7 +151,7 @@ class LLMProvider:
         messages: list[dict],
         config: AgentConfig,
         tools: list[dict] | None = None,
-    ) -> AsyncGenerator[str | ToolCall | dict, None]:
+    ) -> AsyncGenerator[str | ToolCall | ThinkingChunk | dict, None]:
         async for chunk in LLMProvider._stream_with_retry(messages, config, tools):
             yield chunk
 
@@ -217,7 +229,7 @@ class LLMProvider:
         messages: list[dict],
         config: AgentConfig,
         tools: list[dict] | None = None,
-    ) -> AsyncGenerator[str | ToolCall | dict, None]:
+    ) -> AsyncGenerator[str | ToolCall | ThinkingChunk | dict, None]:
         last_error = None
         for attempt in range(3):
             try:
@@ -319,7 +331,7 @@ class LLMProvider:
         messages: list[dict],
         config: AgentConfig,
         tools: list[dict] | None,
-    ) -> AsyncGenerator[str | ToolCall | dict, None]:
+    ) -> AsyncGenerator[str | ToolCall | ThinkingChunk | dict, None]:
         client = LLMProvider._openai_client(config)
         model = LLMProvider._normalize_model(config.model_name, config.custom_providers)
 
@@ -357,6 +369,11 @@ class LLMProvider:
             delta = chunk.choices[0].delta
             if delta is None:
                 continue
+
+            # Reasoning content (OpenAI o1/o3 reasoning models)
+            reasoning = getattr(delta, "reasoning_content", None)
+            if reasoning:
+                yield ThinkingChunk(text=reasoning)
 
             # Text content
             if delta.content:
@@ -533,12 +550,20 @@ class LLMProvider:
         if anthropic_tools:
             params["tools"] = anthropic_tools
 
+        # Enable extended thinking for compatible models (Claude 3.7+, Claude 4+)
+        if LLMProvider._supports_thinking(config.model_name):
+            params["max_tokens"] = 16000
+            params["thinking"] = {"type": "enabled", "budget_tokens": 10000}
+
         params["extra_headers"] = {"anthropic-beta": "prompt-caching-2024-07-31"}
         response = await client.messages.create(**params)
 
         tool_calls = []
         text_content = ""
         for block in response.content:
+            if block.type == "thinking":
+                # Thinking blocks are not included in the response text
+                continue
             if block.type == "text":
                 text_content += block.text
             elif block.type == "tool_use":
@@ -564,7 +589,7 @@ class LLMProvider:
         messages: list[dict],
         config: AgentConfig,
         tools: list[dict] | None,
-    ) -> AsyncGenerator[str | ToolCall | dict, None]:
+    ) -> AsyncGenerator[str | ToolCall | ThinkingChunk | dict, None]:
         model = LLMProvider._normalize_model(config.model_name, config.custom_providers)
         client = LLMProvider._anthropic_client(config)
         system_prompt, chat_msgs = LLMProvider._to_anthropic_messages(messages)
@@ -582,11 +607,19 @@ class LLMProvider:
         if anthropic_tools:
             params["tools"] = anthropic_tools
 
+        # Enable extended thinking for compatible models (Claude 3.7+, Claude 4+)
+        if LLMProvider._supports_thinking(config.model_name):
+            params["max_tokens"] = 16000
+            params["thinking"] = {"type": "enabled", "budget_tokens": 10000}
+
         params["extra_headers"] = {"anthropic-beta": "prompt-caching-2024-07-31"}
         async with client.messages.stream(**params) as stream:
             async for event in stream:
                 if event.type == "content_block_delta":
-                    if event.delta.type == "text_delta":
+                    if event.delta.type == "thinking_delta":
+                        # Extended thinking content
+                        yield ThinkingChunk(text=event.delta.thinking)
+                    elif event.delta.type == "text_delta":
                         yield event.delta.text
 
                 if event.type == "message_delta" and event.usage:

--- a/backend/openmlr/agent/llm.py
+++ b/backend/openmlr/agent/llm.py
@@ -528,16 +528,15 @@ class LLMProvider:
         return AsyncAnthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 
     @staticmethod
-    async def _call_anthropic(
-        messages: list[dict],
-        config: AgentConfig,
+    def _build_anthropic_params(
+        model: str,
+        chat_msgs: list[dict],
+        system_prompt: str,
         tools: list[dict] | None,
-    ) -> LLMResult:
-        model = LLMProvider._normalize_model(config.model_name, config.custom_providers)
-        client = LLMProvider._anthropic_client(config)
-        system_prompt, chat_msgs = LLMProvider._to_anthropic_messages(messages)
-
-        params = {"model": model, "messages": chat_msgs, "max_tokens": 4096}
+        model_name: str,
+    ) -> dict:
+        """Build the params dict shared by _call_anthropic and _stream_anthropic."""
+        params: dict = {"model": model, "messages": chat_msgs, "max_tokens": 4096}
         if system_prompt:
             params["system"] = [
                 {
@@ -549,13 +548,26 @@ class LLMProvider:
         anthropic_tools = LLMProvider._anthropic_tool_param(tools)
         if anthropic_tools:
             params["tools"] = anthropic_tools
-
         # Enable extended thinking for compatible models (Claude 3.7+, Claude 4+)
-        if LLMProvider._supports_thinking(config.model_name):
+        if LLMProvider._supports_thinking(model_name):
             params["max_tokens"] = 16000
             params["thinking"] = {"type": "enabled", "budget_tokens": 10000}
-
         params["extra_headers"] = {"anthropic-beta": "prompt-caching-2024-07-31"}
+        return params
+
+    @staticmethod
+    async def _call_anthropic(
+        messages: list[dict],
+        config: AgentConfig,
+        tools: list[dict] | None,
+    ) -> LLMResult:
+        model = LLMProvider._normalize_model(config.model_name, config.custom_providers)
+        client = LLMProvider._anthropic_client(config)
+        system_prompt, chat_msgs = LLMProvider._to_anthropic_messages(messages)
+
+        params = LLMProvider._build_anthropic_params(
+            model, chat_msgs, system_prompt, tools, config.model_name
+        )
         response = await client.messages.create(**params)
 
         tool_calls = []
@@ -594,25 +606,9 @@ class LLMProvider:
         client = LLMProvider._anthropic_client(config)
         system_prompt, chat_msgs = LLMProvider._to_anthropic_messages(messages)
 
-        params = {"model": model, "messages": chat_msgs, "max_tokens": 4096}
-        if system_prompt:
-            params["system"] = [
-                {
-                    "type": "text",
-                    "text": system_prompt,
-                    "cache_control": {"type": "ephemeral"},
-                }
-            ]
-        anthropic_tools = LLMProvider._anthropic_tool_param(tools)
-        if anthropic_tools:
-            params["tools"] = anthropic_tools
-
-        # Enable extended thinking for compatible models (Claude 3.7+, Claude 4+)
-        if LLMProvider._supports_thinking(config.model_name):
-            params["max_tokens"] = 16000
-            params["thinking"] = {"type": "enabled", "budget_tokens": 10000}
-
-        params["extra_headers"] = {"anthropic-beta": "prompt-caching-2024-07-31"}
+        params = LLMProvider._build_anthropic_params(
+            model, chat_msgs, system_prompt, tools, config.model_name
+        )
         async with client.messages.stream(**params) as stream:
             async for event in stream:
                 if event.type == "content_block_delta":

--- a/backend/openmlr/agent/loop.py
+++ b/backend/openmlr/agent/loop.py
@@ -2,13 +2,14 @@
 
 import asyncio
 import json
+import time
 import traceback
 
 from ..config import AgentConfig
 from .doom_loop import detect_doom_loop
 from .llm import LLMProvider
 from .session import Session
-from .types import AgentEvent, LLMResult, Message, OpType, Submission, ToolCall
+from .types import AgentEvent, LLMResult, Message, OpType, Submission, ThinkingChunk, ToolCall
 
 
 def _append_hint_to_last_user_msg(messages: list[Message], hint: str) -> None:
@@ -319,12 +320,35 @@ async def _stream_llm_call(
     content_buffer = ""
     tool_calls: list[ToolCall] = []
     usage_data = None
+    thinking_started: float | None = None
+    was_thinking = False
 
     async for chunk in LLMProvider.generate_stream(messages, session.config, tools):
         if session.is_cancelled():
             return None
 
-        if isinstance(chunk, str):
+        if isinstance(chunk, ThinkingChunk):
+            # Extended thinking / reasoning content
+            if thinking_started is None:
+                thinking_started = time.time()
+            was_thinking = True
+            await session.emit(
+                AgentEvent(
+                    event_type="thinking_chunk",
+                    data={"chunk": chunk.text},
+                )
+            )
+        elif isinstance(chunk, str):
+            # Transition from thinking to text — emit thinking_end
+            if was_thinking:
+                duration = time.time() - thinking_started if thinking_started else 0
+                await session.emit(
+                    AgentEvent(
+                        event_type="thinking_end",
+                        data={"duration_seconds": round(duration, 1)},
+                    )
+                )
+                was_thinking = False
             content_buffer += chunk
             await session.emit(
                 AgentEvent(
@@ -333,6 +357,16 @@ async def _stream_llm_call(
                 )
             )
         elif isinstance(chunk, ToolCall):
+            # Transition from thinking to tool call — emit thinking_end
+            if was_thinking:
+                duration = time.time() - thinking_started if thinking_started else 0
+                await session.emit(
+                    AgentEvent(
+                        event_type="thinking_end",
+                        data={"duration_seconds": round(duration, 1)},
+                    )
+                )
+                was_thinking = False
             tool_calls.append(chunk)
             await session.emit(
                 AgentEvent(
@@ -349,6 +383,16 @@ async def _stream_llm_call(
         elif isinstance(chunk, dict):
             if chunk.get("event") == "usage":
                 usage_data = chunk.get("usage")
+
+    # If thinking was still active at end of stream (no text/tool followed), close it
+    if was_thinking and thinking_started:
+        duration = time.time() - thinking_started
+        await session.emit(
+            AgentEvent(
+                event_type="thinking_end",
+                data={"duration_seconds": round(duration, 1)},
+            )
+        )
 
     if content_buffer or tool_calls:
         await session.emit(AgentEvent(event_type="assistant_stream_end"))

--- a/backend/openmlr/agent/types.py
+++ b/backend/openmlr/agent/types.py
@@ -7,6 +7,13 @@ from typing import Any
 
 
 @dataclass
+class ThinkingChunk:
+    """A chunk of thinking/reasoning content from the LLM."""
+
+    text: str
+
+
+@dataclass
 class ToolCall:
     """A tool call requested by the LLM."""
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -480,12 +480,50 @@ function ChatUI({
           return [...prev, { id: nextId(), role: 'system', content: '::thinking::' }];
         });
         break;
+      case 'thinking_chunk': {
+        const tchunk = data?.chunk || '';
+        if (!tchunk) break;
+        setMessages((prev) => {
+          // Remove plain ::thinking:: indicator if present
+          let msgs = prev;
+          if (msgs.length > 0 && msgs[msgs.length - 1].content === '::thinking::') msgs = msgs.slice(0, -1);
+          // Append to existing thinking message or create new one
+          const last = msgs[msgs.length - 1];
+          if (last?.role === 'system' && last.content === '::thinking_content::') {
+            const updated = [...msgs];
+            updated[updated.length - 1] = { ...last, thinking: (last.thinking || '') + tchunk };
+            return updated;
+          }
+          return [...msgs, { id: nextId(), role: 'system', content: '::thinking_content::', thinking: tchunk }];
+        });
+        break;
+      }
+      case 'thinking_end': {
+        const duration = data?.duration_seconds || 0;
+        setMessages((prev) => {
+          const idx = findLastIndex(prev, (m: Message) => m.role === 'system' && m.content === '::thinking_content::');
+          if (idx >= 0) {
+            const updated = [...prev];
+            updated[idx] = { ...updated[idx], thinkingDuration: duration };
+            return updated;
+          }
+          return prev;
+        });
+        break;
+      }
       case 'assistant_chunk': {
         const chunk = data?.chunk || data?.content || '';
         if (!chunk) break;
         setMessages((prev) => {
           let msgs = prev;
+          // Remove plain ::thinking:: indicator if present
           if (msgs.length > 0 && msgs[msgs.length - 1].content === '::thinking::') msgs = msgs.slice(0, -1);
+          // Collapse thinking block when reply starts
+          const thinkIdx = findLastIndex(msgs, (m: Message) => m.role === 'system' && m.content === '::thinking_content::' && !m.thinkingCollapsed);
+          if (thinkIdx >= 0) {
+            msgs = [...msgs];
+            msgs[thinkIdx] = { ...msgs[thinkIdx], thinkingCollapsed: true };
+          }
           const last = msgs[msgs.length - 1];
           if (last?.role === 'assistant' && last.streaming) {
             const updated = [...msgs]; updated[updated.length - 1] = { ...last, content: last.content + chunk }; return updated;
@@ -512,7 +550,13 @@ function ChatUI({
         break;
       case 'tool_call':
         setMessages((prev) => {
-          const msgs = prev.filter((m) => !(m.role === 'system' && m.content === '::thinking::'));
+          let msgs = prev.filter((m) => !(m.role === 'system' && m.content === '::thinking::'));
+          // Collapse thinking block when tool call arrives
+          const thinkIdx = findLastIndex(msgs, (m: Message) => m.role === 'system' && m.content === '::thinking_content::' && !m.thinkingCollapsed);
+          if (thinkIdx >= 0) {
+            msgs = [...msgs];
+            msgs[thinkIdx] = { ...msgs[thinkIdx], thinkingCollapsed: true };
+          }
           return [...msgs, { id: nextId(), role: 'tool', content: '', metadata: { tool: data?.tool ?? '', tool_call_id: data?.id, args: typeof data?.arguments === 'string' ? data.arguments.slice(0, 120) : JSON.stringify(data?.arguments ?? {}).slice(0, 120) } }];
         });
         break;
@@ -608,7 +652,11 @@ function ChatUI({
         // Cancel any pending job_complete reload — SSE events already updated state
         if (reloadTimerRef.current) { clearTimeout(reloadTimerRef.current); reloadTimerRef.current = null; }
         setMessages((prev) => {
-          const c = prev.filter((m) => !(m.role === 'system' && m.content === '::thinking::'));
+          // Remove plain thinking indicator, collapse any uncollapsed thinking blocks
+          const c = prev
+            .filter((m) => !(m.role === 'system' && m.content === '::thinking::'))
+            .map((m) => (m.role === 'system' && m.content === '::thinking_content::' && !m.thinkingCollapsed)
+              ? { ...m, thinkingCollapsed: true } : m);
           const last = c[c.length - 1];
           setCurrentConvStatus(last?.role === 'assistant' && last.content.trim().endsWith('?') ? 'waiting_input' : 'idle');
           return c;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -480,35 +480,36 @@ function ChatUI({
           return [...prev, { id: nextId(), role: 'system', content: '::thinking::' }];
         });
         break;
-      case 'thinking_chunk': {
-        const tchunk = data?.chunk || '';
-        if (!tchunk) break;
-        setMessages((prev) => {
-          // Remove plain ::thinking:: indicator if present
-          let msgs = prev;
-          if (msgs.length > 0 && msgs[msgs.length - 1].content === '::thinking::') msgs = msgs.slice(0, -1);
-          // Append to existing thinking message or create new one
-          const last = msgs[msgs.length - 1];
-          if (last?.role === 'system' && last.content === '::thinking_content::') {
-            const updated = [...msgs];
-            updated[updated.length - 1] = { ...last, thinking: (last.thinking || '') + tchunk };
-            return updated;
-          }
-          return [...msgs, { id: nextId(), role: 'system', content: '::thinking_content::', thinking: tchunk }];
-        });
-        break;
-      }
+      case 'thinking_chunk':
       case 'thinking_end': {
-        const duration = data?.duration_seconds || 0;
-        setMessages((prev) => {
-          const idx = findLastIndex(prev, (m: Message) => m.role === 'system' && m.content === '::thinking_content::');
-          if (idx >= 0) {
-            const updated = [...prev];
-            updated[idx] = { ...updated[idx], thinkingDuration: duration };
-            return updated;
-          }
-          return prev;
-        });
+        if (event_type === 'thinking_chunk') {
+          const tchunk = data?.chunk || '';
+          if (!tchunk) break;
+          setMessages((prev) => {
+            // Remove plain ::thinking:: indicator if present
+            let msgs = prev;
+            if (msgs.length > 0 && msgs[msgs.length - 1].content === '::thinking::') msgs = msgs.slice(0, -1);
+            // Append to existing thinking message or create new one
+            const last = msgs[msgs.length - 1];
+            if (last?.role === 'system' && last.content === '::thinking_content::') {
+              const updated = [...msgs];
+              updated[updated.length - 1] = { ...last, thinking: (last.thinking || '') + tchunk };
+              return updated;
+            }
+            return [...msgs, { id: nextId(), role: 'system', content: '::thinking_content::', thinking: tchunk }];
+          });
+        } else {
+          const duration = data?.duration_seconds || 0;
+          setMessages((prev) => {
+            const idx = findLastIndex(prev, (m: Message) => m.role === 'system' && m.content === '::thinking_content::');
+            if (idx >= 0) {
+              const updated = [...prev];
+              updated[idx] = { ...updated[idx], thinkingDuration: duration };
+              return updated;
+            }
+            return prev;
+          });
+        }
         break;
       }
       case 'assistant_chunk': {

--- a/frontend/src/components/InputArea.tsx
+++ b/frontend/src/components/InputArea.tsx
@@ -250,8 +250,8 @@ export const InputArea = React.memo(function InputArea({ disabled, showStop, mod
             />
           </div>
           
-          {/* Stop button */}
-          {showStop && (
+          {/* Stop button — only during active processing (not waiting_input/waiting_approval) */}
+          {showStop && disabled && (
             <button 
               className="h-11 w-11 rounded-lg flex items-center justify-center bg-error text-white hover:opacity-90 transition-all shrink-0"
               onClick={onStop} 

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -125,6 +125,65 @@ function SubAgentBlock({ msg, expanded, onToggle }: { msg: Message; expanded: bo
   );
 }
 
+/** Format thinking duration into human-readable text */
+function formatThinkingDuration(seconds?: number): string {
+  if (!seconds) return 'a moment';
+  if (seconds < 2) return '1 second';
+  if (seconds < 60) return `${Math.round(seconds)} seconds`;
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  if (s === 0) return `${m} minute${m !== 1 ? 's' : ''}`;
+  return `${m}m ${s}s`;
+}
+
+/** Thinking/reasoning block — shows model thinking, collapses when reply starts */
+function ThinkingBlock({ msg, expanded, onToggle }: { msg: Message; expanded: boolean; onToggle: () => void }) {
+  const thinking = msg.thinking || '';
+  const duration = msg.thinkingDuration;
+  const collapsed = msg.thinkingCollapsed;
+
+  if (!collapsed) {
+    // Active thinking — show faded content with streaming indicator
+    return (
+      <div className="max-w-[95%] rounded-lg border border-border/40 bg-surface/30 px-4 py-3 mt-1">
+        <div className="flex items-center gap-2 mb-2 text-xs text-text-dim">
+          <span className="flex gap-1">
+            <span className="w-1.5 h-1.5 bg-primary/60 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
+            <span className="w-1.5 h-1.5 bg-primary/60 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
+            <span className="w-1.5 h-1.5 bg-primary/60 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
+          </span>
+          <span>Thinking...</span>
+        </div>
+        <pre className="whitespace-pre-wrap text-sm text-text-dim/50 leading-relaxed m-0 p-0 bg-transparent max-h-48 overflow-y-auto font-sans">
+          {thinking}
+          <span className="inline-block w-[2px] h-[1em] bg-text-dim/30 animate-pulse align-middle ml-0.5" />
+        </pre>
+      </div>
+    );
+  }
+
+  // Collapsed — show summary label, clickable to expand
+  return (
+    <div className="max-w-[95%]">
+      <button
+        className="flex items-center gap-2 text-xs text-text-dim/60 hover:text-text-dim transition-colors py-1 bg-transparent border-none cursor-pointer"
+        onClick={onToggle}
+        title="Click to expand thinking"
+      >
+        <span className="text-text-dim/40">{expanded ? '\u25BC' : '\u25B6'}</span>
+        <span>Thought for {formatThinkingDuration(duration)}</span>
+      </button>
+      {expanded && thinking && (
+        <div className="rounded-lg border border-border/40 bg-surface/30 px-4 py-3 mt-1">
+          <pre className="whitespace-pre-wrap text-sm text-text-dim/50 leading-relaxed m-0 p-0 bg-transparent max-h-64 overflow-y-auto font-sans">
+            {thinking}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
 /** Individual message row — memoized to skip re-renders when other messages update */
 const MessageRow = React.memo(function MessageRow({ msg, isExpanded, onToggle }: {
   msg: Message;
@@ -152,18 +211,14 @@ const MessageRow = React.memo(function MessageRow({ msg, isExpanded, onToggle }:
         </div>
       )}
 
-      {/* Assistant messages — defer markdown while streaming for performance */}
+      {/* Assistant messages — render markdown seamlessly during streaming */}
       {msg.role === 'assistant' && (
         <div className="prose max-w-[95%] mt-1">
-          {msg.streaming ? (
-            <pre className="whitespace-pre-wrap font-sans text-text leading-relaxed m-0 p-0 bg-transparent prose-sm">
-              {msg.content}
-              <span className="inline-block w-[2px] h-[1em] bg-primary animate-pulse align-middle ml-0.5" />
-            </pre>
-          ) : (
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>
-              {msg.content}
-            </ReactMarkdown>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            {msg.content}
+          </ReactMarkdown>
+          {msg.streaming && (
+            <span className="inline-block w-[2px] h-[1em] bg-primary animate-pulse align-middle ml-0.5" />
           )}
         </div>
       )}
@@ -186,7 +241,7 @@ const MessageRow = React.memo(function MessageRow({ msg, isExpanded, onToggle }:
         />
       )}
 
-      {/* Thinking indicator */}
+      {/* Thinking indicator (before any thinking content arrives) */}
       {msg.role === 'system' && msg.content === '::thinking::' && (
         <div className="flex items-center gap-3 py-3 text-text-dim">
           <span className="flex gap-1">
@@ -198,8 +253,17 @@ const MessageRow = React.memo(function MessageRow({ msg, isExpanded, onToggle }:
         </div>
       )}
 
+      {/* Thinking content block (streaming or collapsed) */}
+      {msg.role === 'system' && msg.content === '::thinking_content::' && (
+        <ThinkingBlock
+          msg={msg}
+          expanded={isExpanded}
+          onToggle={handleToggle}
+        />
+      )}
+
       {/* System messages */}
-      {msg.role === 'system' && msg.content !== '::thinking::' && (
+      {msg.role === 'system' && msg.content !== '::thinking::' && msg.content !== '::thinking_content::' && (
         <div className="text-sm text-text-dim italic py-2 px-3 bg-surface/50 rounded-md">
           {msg.content}
         </div>

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -132,12 +132,12 @@ function formatThinkingDuration(seconds?: number): string {
   if (seconds < 60) return `${Math.round(seconds)} seconds`;
   const m = Math.floor(seconds / 60);
   const s = Math.round(seconds % 60);
-  if (s === 0) return `${m} minute${m !== 1 ? 's' : ''}`;
+  if (s === 0) return `${m} minute${m === 1 ? '' : 's'}`;
   return `${m}m ${s}s`;
 }
 
 /** Thinking/reasoning block — shows model thinking, collapses when reply starts */
-function ThinkingBlock({ msg, expanded, onToggle }: { msg: Message; expanded: boolean; onToggle: () => void }) {
+function ThinkingBlock({ msg, expanded, onToggle }: Readonly<{ msg: Message; expanded: boolean; onToggle: () => void }>) {
   const thinking = msg.thinking || '';
   const duration = msg.thinkingDuration;
   const collapsed = msg.thinkingCollapsed;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -20,6 +20,12 @@ export interface Message {
   duration?: number;
   model?: string;
   mode?: string;
+  /** Accumulated thinking/reasoning content from the LLM */
+  thinking?: string;
+  /** Duration in seconds the model spent thinking */
+  thinkingDuration?: number;
+  /** Whether the thinking block is collapsed (model started replying) */
+  thinkingCollapsed?: boolean;
   metadata?: {
     tool?: string;
     args?: string;


### PR DESCRIPTION
This pull request adds support for streaming and displaying "thinking" or reasoning content from advanced LLMs (such as Claude 3.7+ and OpenAI's reasoning models) before the main assistant reply. It introduces a new `ThinkingChunk` type, updates backend streaming and event handling, and enhances the frontend UI to show and manage these thinking segments, including duration and collapsing/expanding the block.

**Backend: Extended "thinking" support for LLMs**
- Added a `ThinkingChunk` type and logic to detect and stream reasoning/thinking content from compatible models (Claude 3.7+, Claude 4+, OpenAI reasoning models). (`backend/openmlr/agent/types.py` [[1]](diffhunk://#diff-15dbfb804b88b5099de6cb8bc312dba7562af10dbd8a085dedc1298db8290ed7R9-R15) `backend/openmlr/agent/llm.py` [[2]](diffhunk://#diff-eb3f789fa9de0a78a781d7aa86c6b171c628da30a25d1d61ba843c3ad640e5f3L9-R9) [[3]](diffhunk://#diff-eb3f789fa9de0a78a781d7aa86c6b171c628da30a25d1d61ba843c3ad640e5f3R115-R126) [[4]](diffhunk://#diff-eb3f789fa9de0a78a781d7aa86c6b171c628da30a25d1d61ba843c3ad640e5f3L142-R154) [[5]](diffhunk://#diff-eb3f789fa9de0a78a781d7aa86c6b171c628da30a25d1d61ba843c3ad640e5f3L220-R232) [[6]](diffhunk://#diff-eb3f789fa9de0a78a781d7aa86c6b171c628da30a25d1d61ba843c3ad640e5f3L322-R334) [[7]](diffhunk://#diff-eb3f789fa9de0a78a781d7aa86c6b171c628da30a25d1d61ba843c3ad640e5f3R373-R377) [[8]](diffhunk://#diff-eb3f789fa9de0a78a781d7aa86c6b171c628da30a25d1d61ba843c3ad640e5f3R553-R566) [[9]](diffhunk://#diff-eb3f789fa9de0a78a781d7aa86c6b171c628da30a25d1d61ba843c3ad640e5f3L567-R592) [[10]](diffhunk://#diff-eb3f789fa9de0a78a781d7aa86c6b171c628da30a25d1d61ba843c3ad640e5f3R610-R622)
- Updated streaming and retry functions to yield `ThinkingChunk` objects as appropriate. (`backend/openmlr/agent/llm.py` [[1]](diffhunk://#diff-eb3f789fa9de0a78a781d7aa86c6b171c628da30a25d1d61ba843c3ad640e5f3L142-R154) [[2]](diffhunk://#diff-eb3f789fa9de0a78a781d7aa86c6b171c628da30a25d1d61ba843c3ad640e5f3L220-R232) [[3]](diffhunk://#diff-eb3f789fa9de0a78a781d7aa86c6b171c628da30a25d1d61ba843c3ad640e5f3L322-R334) [[4]](diffhunk://#diff-eb3f789fa9de0a78a781d7aa86c6b171c628da30a25d1d61ba843c3ad640e5f3L567-R592)
- Modified the agent loop to emit `thinking_chunk` and `thinking_end` events, including timing the duration of the thinking phase and handling transitions to assistant output or tool calls. (`backend/openmlr/agent/loop.py` [[1]](diffhunk://#diff-9737df0f9eefb15fa8eb2e58a1e0dc9c23d38646ffa244b7b5b5560df550f4c9R5-R12) [[2]](diffhunk://#diff-9737df0f9eefb15fa8eb2e58a1e0dc9c23d38646ffa244b7b5b5560df550f4c9R323-R351) [[3]](diffhunk://#diff-9737df0f9eefb15fa8eb2e58a1e0dc9c23d38646ffa244b7b5b5560df550f4c9R360-R369) [[4]](diffhunk://#diff-9737df0f9eefb15fa8eb2e58a1e0dc9c23d38646ffa244b7b5b5560df550f4c9R387-R396)

**Frontend: Thinking content UI and event handling**
- Enhanced the chat UI to display streamed thinking content as a special block, collapse it when the assistant reply or tool call starts, and show the duration of the thinking phase. Users can expand/collapse the block to review the reasoning. (`frontend/src/App.tsx` [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR483-R526) [[2]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL515-R559) [[3]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL611-R659) `frontend/src/components/MessageList.tsx` [[4]](diffhunk://#diff-cc53486d1085f8d918b21f26567327f4d1efad215369f415a5b94a71328802b6R128-R186) [[5]](diffhunk://#diff-cc53486d1085f8d918b21f26567327f4d1efad215369f415a5b94a71328802b6L155-R221) [[6]](diffhunk://#diff-cc53486d1085f8d918b21f26567327f4d1efad215369f415a5b94a71328802b6L189-R244) [[7]](diffhunk://#diff-cc53486d1085f8d918b21f26567327f4d1efad215369f415a5b94a71328802b6R256-R266)
- Updated the stop button logic to only show during active processing, not while waiting for input/approval. (`frontend/src/components/InputArea.tsx` [frontend/src/components/InputArea.tsxL253-R254](diffhunk://#diff-f5509c1e50bdfc9bf437b5798a382f523b909bd7a00a8efa33c4342629bf1d86L253-R254))

These changes improve transparency and user experience by surfacing the model's intermediate reasoning steps in real time.